### PR TITLE
fix: Update LICENSE format for GitHub detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -193,8 +193,9 @@
       same page as the copyright notice for easier identification within
       third-party archives.
 
-   Copyright 2021 encircle360 GmbH
    Copyright 2024 denkhaus
+
+   Original work Copyright 2021 encircle360 GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## 📋 Description
Updates the LICENSE file format to ensure GitHub can properly detect the Apache 2.0 license.

## 🔗 Related Issue
Fixes license detection issue where GitHub shows 'Other' instead of 'Apache-2.0'

## 🚀 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 📝 Changes Made
- Reorder copyright notices to standard Apache 2.0 format
- Primary copyright: 2024 denkhaus (current maintainer)  
- Original work attribution: 2021 encircle360 GmbH
- Maintains proper attribution while following GitHub's detection patterns

## 🧪 Testing
- [x] LICENSE file follows standard Apache 2.0 format
- [x] All copyright attributions preserved
- [x] Should be detected by GitHub as Apache-2.0

## 📚 Documentation
- [x] Documentation changes are not needed

## 🔍 Expected Result
GitHub should now properly detect and display 'Apache-2.0' license instead of 'Other'.