### PR TITLE
feat: Increment chart version to 1.0.1 with proper release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
   pull_request:
 
 jobs:

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: outline
 description: Secure Helm chart for Outline wiki with mandatory Kubernetes secrets
-version: 1.0.0
+version: 1.0.1
 appVersion: 0.85.1
 home: https://github.com/denkhaus/outline-helm
 icon: https://raw.githubusercontent.com/outline/outline/main/public/images/icon-512.png


### PR DESCRIPTION
## 📋 Description
Increments chart version to 1.0.1 and adds workflow dispatch trigger to fix the release tag format issue.

## 🔗 Related Issue
Fixes the issue where Helm cannot find chart version due to incorrect tag format (outline-1.0.0 vs v1.0.1).

## 🚀 Type of Change
- [x] ✨ New feature (version bump with corrected release process)

## 📝 Changes Made
- Bump chart version from 1.0.0 to 1.0.1
- Add workflow_dispatch trigger to release workflow for manual triggering
- Chart-releaser will now use the corrected release-name-template

## 🎯 Expected Result
- Chart-releaser will create release with tag `v1.0.1` (correct format)
- Helm repository index will have proper download URLs
- `helm install` commands will work correctly

## 🔍 Why Version Bump
- Previous v1.0.0 had incorrect tag format (outline-1.0.0)
- v1.0.1 will be the first release with proper semantic versioning tags
- This ensures clean release history going forward

## 🧪 Testing
After merge, the release workflow will:
1. Detect chart version 1.0.1
2. Create release with tag v1.0.1 (proper format)
3. Update Helm repository index
4. Enable successful chart installation